### PR TITLE
Fix external site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Intrinsic SDK Examples
 
-This is a repository of example skill implementations using the [Intrinsic SDK](github.com/intrinsic-ai/sdk).
+This is a repository of example skill implementations using the [Intrinsic SDK](https://github.com/intrinsic-ai/sdk).
 
 ## Disclaimer
 
 As Flowstate and the SDK are in beta, the contents of this repository are subject to change.
-Use of this repository requires participation in the beta for Intrinsic Flowstate, which is accepting [applications](intrinsic.ai/beta).
+Use of this repository requires participation in the beta for Intrinsic Flowstate, which is accepting [applications](https://intrinsic.ai/beta).
 Access to this repository is subject to the associated [LICENSE](LICENSE).
 


### PR DESCRIPTION
Looks like these links were being resolved as relative to the repo, leading to 404s. I'm not sure if just adding `https://` is best practice but it works.